### PR TITLE
Guarantee clean workspace on windows 

### DIFF
--- a/src/Microsoft.DotNet.HelixPoolProvider.csproj
+++ b/src/Microsoft.DotNet.HelixPoolProvider.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
We had some weird stuff like this where killing known leaky processes went bad:

```
F:\dotnetbuild\work\7c4dcf36-21a6-40c2-b8c3-4fce589ada83\Work\ed8b0b33-28be-435f-be1c-c759e3466f2f\Exec>taskkill -f -im dotnet.exe 
ERROR: The process "dotnet.exe" with PID 8572 could not be terminated.
Reason: There is no running instance of the task.
...
F:\dotnetbuild\work\7c4dcf36-21a6-40c2-b8c3-4fce589ada83\Work\ed8b0b33-28be-435f-be1c-c759e3466f2f\Exec>rmdir /S /Q F:\workspace 
F:\workspace\_work\1\s\.dotnet\dotnet.exe - Access is denied.
```

But also, it's possible for other things to leak handles to files.  This change causes it to pick a totally new workspace folder, all the while trying to delete any it finds on that quest; since we need to succeed though and because these machines have big disks, we can tolerate dozens of this problem before it becomes too bad.