### PR TITLE
Prevent magic environment variable reading

### DIFF
--- a/src/HelixJobCreator.cs
+++ b/src/HelixJobCreator.cs
@@ -104,6 +104,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
                     .WithCommand(ConstructCommand())
                     .WithFiles(credentialsPath, agentSettingsPath, StartupScriptPath)
                     .WithTimeout(TimeSpan.FromMinutes((double)_configuration.TimeoutInMinutes))
+                    .WithSource($"agent/{_agentRequestItem.accountId}/{_orchestrationId}/{_jobName}/")
                     .AttachToJob()
                     .SendAsync();
 

--- a/src/HelixJobCreator.cs
+++ b/src/HelixJobCreator.cs
@@ -100,11 +100,11 @@ namespace Microsoft.DotNet.HelixPoolProvider
                     .WithContainerName(_configuration.ContainerName)
                     .WithCorrelationPayloadUris(AgentPayloadUri)
                     .WithStorageAccountConnectionString(_configuration.ConnectionString)
+                    .WithSource($"agent/{_agentRequestItem.accountId}/{_orchestrationId}/{_jobName}/")
                     .DefineWorkItem(_agentRequestItem.agentId)
                     .WithCommand(ConstructCommand())
                     .WithFiles(credentialsPath, agentSettingsPath, StartupScriptPath)
                     .WithTimeout(TimeSpan.FromMinutes((double)_configuration.TimeoutInMinutes))
-                    .WithSource($"agent/{_agentRequestItem.accountId}/{_orchestrationId}/{_jobName}/")
                     .AttachToJob()
                     .SendAsync();
 


### PR DESCRIPTION
Works around the problem from earlier today;  if you don't specify a source, you now get stuff from the environment, which assumes you're running in the context of an Azure DevOps build.