### PR TITLE
Remove Creator

### DIFF
--- a/src/HelixJobCreator.cs
+++ b/src/HelixJobCreator.cs
@@ -96,7 +96,6 @@ namespace Microsoft.DotNet.HelixPoolProvider
                 var job = await _api.Job.Define()
                     .WithType($"byoc/{_configuration.HelixCreator}/")
                     .WithTargetQueue(_queueInfo.QueueId)
-                    .WithCreator(_configuration.HelixCreator)
                     .WithContainerName(_configuration.ContainerName)
                     .WithCorrelationPayloadUris(AgentPayloadUri)
                     .WithStorageAccountConnectionString(_configuration.ConnectionString)


### PR DESCRIPTION
Remove creator - prevents impersonation warning when the reported name isn't the same as the token used, additionally Creator was never meant to be specified when using nonymous access.