### PR TITLE
Store off _diag log folder for agents

### DIFF
--- a/src/wwwroot/startupscripts/startagent-linux.sh
+++ b/src/wwwroot/startupscripts/startagent-linux.sh
@@ -17,10 +17,16 @@ $workspace_path/run.sh
 
 # Expect an exit code of 2, which is what is given when the agent connection is revoked
 lastexitcode=$?
+
+if [ -d "$workspace_path/_diag" ]; then
+  echo "Copying _diag folder to upload root"
+  cp -r "$workspace_path/_diag" $HELIX_WORKITEM_UPLOAD_ROOT
+fi
+
 if [[ $lastexitcode -ne 0 ]]; then
-	echo "Unexpected error returned from agent: $lastexitcode"
-	exit $lastexitcode
+    echo "Unexpected error returned from agent: $lastexitcode"
+    exit $lastexitcode
 else
-	echo "Agent disconnected successfully, exiting"
-	exit 0
+    echo "Agent disconnected successfully, exiting"
+    exit 0
 fi

--- a/src/wwwroot/startupscripts/startagent-win.cmd
+++ b/src/wwwroot/startupscripts/startagent-win.cmd
@@ -35,6 +35,9 @@ REM At this point the agent job is done.  If we had a non-delete-able workspace,
 REM we'll want to reboot to kill any mystery processes left running which caused this.
 if "%reboot_required%"=="true" (call %HELIX_PYTHONPATH% -c "from helix.platformutil import reboot_machine; reboot_machine()" )
 
+REM The above reboot prevents uploading logs; if we got past it, preserve the diag logs for future use.
+IF EXIST "%WORKSPACEPATH%\_diag" (xcopy /s /y "%WORKSPACEPATH%\_diag\*" "%HELIX_WORKITEM_UPLOAD_ROOT%" )
+
 if not "%LASTEXITCODE%" == "0" (
     echo "Unexpected error returned from agent: %LASTEXITCODE%"
     exit /b 1


### PR DESCRIPTION
To help investigate pool provider timeouts, let's store off the _diag folder if we can. 