### PR TITLE
Make the parents to workspace_path readable

### DIFF
--- a/src/wwwroot/startupscripts/startagent-linux.sh
+++ b/src/wwwroot/startupscripts/startagent-linux.sh
@@ -8,6 +8,15 @@ sudo mkdir $workspace_path
 # Make it writeable
 sudo chmod -R 777 $workspace_path
 
+# Make its parents readable
+if [ -d "$workspace_path/.." ]; then
+  sudo chmod +r $workspace_path/..
+fi
+
+if [ -d "$workspace_path/../.." ]; then
+  sudo chmod +r $workspace_path/../..
+fi
+
 # copy .agent and .credentials files to workspace path
 cp -f -r $HELIX_CORRELATION_PAYLOAD/* $workspace_path
 cp -f $HELIX_WORKITEM_PAYLOAD/.agent $workspace_path


### PR DESCRIPTION
Since 2/17, scheduled builds for arcade-validation have been failing because when we try to create the workspace directory, the workspace directory parents aren't readable. This change chmods the immediate two parents, after confirming they exist.