### PR TITLE
Return empty status when no agentData

### DIFF
--- a/src/Controllers/PoolProviderController.cs
+++ b/src/Controllers/PoolProviderController.cs
@@ -345,7 +345,7 @@ namespace Microsoft.DotNet.HelixPoolProvider.Controllers
                 // This means the call came back before we've provisioned it.  We don't have any meaningful
                 // response right now, so return the empty string to reflect "no status".
                 _logger.LogInformation("Status request has no agentData, returning empty status");
-                return Json("");
+                return NoContent();
             }
 
             WorkItemDetails workItemDetails;

--- a/src/Controllers/PoolProviderController.cs
+++ b/src/Controllers/PoolProviderController.cs
@@ -338,7 +338,15 @@ namespace Microsoft.DotNet.HelixPoolProvider.Controllers
             // Need to know the job correlation id and work item id.
             // Work item id is the agent id, and job correlation is in the agent data.
             string workItemId = agentRequestStatusItem.agentId;
-            string correlationId = agentRequestStatusItem.agentData.correlationId;
+            string correlationId = agentRequestStatusItem.agentData?.correlationId;
+
+            if (string.IsNullOrEmpty(correlationId))
+            {
+                // This means the call came back before we've provisioned it.  We don't have any meaningful
+                // response right now, so return the empty string to reflect "no status".
+                _logger.LogInformation("Status request has no agentData, returning empty status");
+                return Json("");
+            }
 
             WorkItemDetails workItemDetails;
             try

--- a/src/Models/AgentRequestStatusItem.cs
+++ b/src/Models/AgentRequestStatusItem.cs
@@ -12,7 +12,6 @@ namespace Microsoft.DotNet.HelixPoolProvider.Models
         public string agentId { get; set; }
         public string accountId { get; set; }
         public string agentPool { get; set; }
-        [Required]
         public AgentDataItem agentData { get; set; }
     }
 }


### PR DESCRIPTION
This will prevent a stream of 400 requests from happening, so that we can more easily monitor when other 400's are present.

Talking with Azure Pipelines folks, this should result in a "waiting for connection" type status, rather than the current "failed to connect" type status.