### PR TITLE
Clean workspace folder after build as well

### DIFF
--- a/src/wwwroot/startupscripts/startagent-linux.sh
+++ b/src/wwwroot/startupscripts/startagent-linux.sh
@@ -49,6 +49,10 @@ fi
 echo Requesting reboot after build completes
 $HELIX_PYTHONPATH -c "from helix.workitemutil import request_reboot; request_reboot('Reboot for build agent hygiene')"
 
+# Repeat the deletion of the workspace directory because for very large builds this can take minutes to complete,
+# which counts towards the queue time of the build it picks up.
+sudo rm -r -f $workspace_path
+
 if [[ $lastexitcode -ne 0 ]]; then
   echo "Unexpected error returned from agent: $lastexitcode"
   exit $lastexitcode

--- a/src/wwwroot/startupscripts/startagent-win.cmd
+++ b/src/wwwroot/startupscripts/startagent-win.cmd
@@ -45,6 +45,11 @@ IF EXIST "%WORKSPACEPATH%\_diag" (xcopy /s /y "%WORKSPACEPATH%\_diag\*" "%HELIX_
 echo Requesting reboot to kill all processes (including possible leaked AzDO agents)
 %HELIX_PYTHONPATH% -c "from helix.workitemutil import request_reboot; request_reboot('Reboot to kill all processes')"
 
+REM Repeat the deletion of the workspace directory because for very large builds this can take minutes to complete,
+REM which counts towards the queue time of the build it picks up.
+robocopy /mir %EMPTYDIR% %WORKSPACEPATH%
+rmdir /S /Q %WORKSPACEPATH%
+
 if not "%LASTEXITCODE%" == "0" (
     echo Unexpected error returned from agent: %LASTEXITCODE%
     exit /b 1


### PR DESCRIPTION
From investigation into https://github.com/dotnet/core-eng/issues/10202 ; 

This saves time for the next work item picked up on the machine, and since extending the 90-minute lifespan of the AzDO token we're given has been slow to arrive, (see dotnet/core-eng#10136  for details), we'll take every second we can save here.