### PR TITLE
#11643: Arcade Pool Provider Component Governance CVE-2020-0603 fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,11 +104,11 @@ jobs:
           pathtoPublish: '$(build.artifactstagingdirectory)'
           artifactName: 'drop'
       - task: ComponentGovernanceComponentDetection@0
-          inputs:
-            # `.packages` directory is used by some tools running during build.
-            # By default ComponentDetection scans this directory and sometimes reports
-            # vulnerabilities for packages that are not part of the published product.
-            # We can ignore this directory because actual vulnerabilities
-            # that we are interested in will be found by the tool
-            # when scanning .csproj and package.json files.
-            ignoreDirectories: '.packages'
+        inputs:
+          # `.packages` directory is used by some tools running during build.
+          # By default ComponentDetection scans this directory and sometimes reports
+          # vulnerabilities for packages that are not part of the published product.
+          # We can ignore this directory because actual vulnerabilities
+          # that we are interested in will be found by the tool
+          # when scanning .csproj and package.json files.
+          ignoreDirectories: '.packages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
     include:
     - master
     - production
-    
+
 pr:
   branches:
     include:
@@ -13,7 +13,7 @@ pr:
   paths:
     exclude:
     - Documentation/*
-    
+
 variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
@@ -22,6 +22,8 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
+  - name: skipComponentGovernanceDetection
+    value: true
 
 jobs:
 - template: /eng/common/templates/jobs/jobs.yml
@@ -85,7 +87,7 @@ jobs:
         clean: true
       # Use utility script to run script command dependent on agent OS.
       - script: $(_Script)
-          -configuration $(_BuildConfig) 
+          -configuration $(_BuildConfig)
           -prepareMachine
           $(_InternalBuildArgs)
           /p:Test=false
@@ -101,3 +103,12 @@ jobs:
         inputs:
           pathtoPublish: '$(build.artifactstagingdirectory)'
           artifactName: 'drop'
+      - task: ComponentGovernanceComponentDetection@0
+          inputs:
+            # `.packages` directory is used by some tools running during build.
+            # By default ComponentDetection scans this directory and sometimes reports
+            # vulnerabilities for packages that are not part of the published product.
+            # We can ignore this directory because actual vulnerabilities
+            # that we are interested in will be found by the tool
+            # when scanning .csproj and package.json files.
+            ignoreDirectories: '.packages'

--- a/global.json
+++ b/global.json
@@ -1,8 +1,4 @@
 {
-    "sdk": {
-        "version": "2.1.519",
-        "rollForward": "minor"
-    },
     "tools": {
         "dotnet": "5.0.100"
     },

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
-    "tools": {
-        "dotnet": "5.0.100"
-    },
-    "msbuild-sdks": {
-        "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.21",
-        "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19568.11"
-    }
+  "tools": {
+    "dotnet": "5.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.21",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19568.11"
+  }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "tools": {
-    "dotnet": "5.0.100"
+    "dotnet": "5.0.100",
+    "runtimes": {
+        "dotnet": [
+          "2.1.23"
+        ]
+      }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.21",

--- a/global.json
+++ b/global.json
@@ -1,14 +1,13 @@
 {
-  "tools": {
-    "dotnet": "5.0.100",
-    "runtimes": {
-        "dotnet": [
-          "2.1.23"
-        ]
-      }
-  },
-  "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.21",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19568.11"
-  }
+    "sdk": {
+        "version": "2.1.519",
+        "rollForward": "minor"
+    },
+    "tools": {
+        "dotnet": "5.0.100"
+    },
+    "msbuild-sdks": {
+        "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.21",
+        "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19568.11"
+    }
 }


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/11643

Vulnerability CVE-2020-0603 detected in component governance. However it's false positive coming from .packages folder.

.packages directory is used by some tools running during build. By default ComponentDetection scans this directory and sometimes reports vulnerabilities for packages that are not part of the published product. We can ignore this directory because actual vulnerabilities that we are interested in will be found by the tool when scanning .csproj and package.json files.

The fix is the same as for arcade-services in dotnet/arcade-services#1466.