### PR TITLE
[DO NOT ROLLOUT] temporarily add azure monitor enabled queue to staging provider

### DIFF
--- a/src/appsettings.dncenginternal-int.json
+++ b/src/appsettings.dncenginternal-int.json
@@ -19,6 +19,8 @@
 
     "BuildPool.Windows.10.Amd64.VS2019.Xaml",
     "BuildPool.Server.Amd64.VS2017.Arcade",
+
+    "pr-buildpool.server.amd64.vs2017.arcade-riarenas-test-azure-mo",
   ],
   "HelixCreator": "helixpoolprovider-dncenginternal-int",
   "TimeoutInMinutes": 600,


### PR DESCRIPTION
This change adds a temporary test queue to the staging pool provider configuration so that we can send arcade official builds to it and analyze the scale set using azure monitor. 