### PR TITLE
Enable .NET analyzers

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
                 catch (Exception e)
                 {
                     _logger.LogError(e, $"Failed to obtain secret {secretName} from keyvault");
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/src/Microsoft.DotNet.HelixPoolProvider.csproj
+++ b/src/Microsoft.DotNet.HelixPoolProvider.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Enable default .NET analyzers for all projects to satisfy SDL requirement.