### PR TITLE
Revert "temporarily add azure monitor enabled queue to staging provid…

### DIFF
--- a/src/appsettings.dncenginternal-int.json
+++ b/src/appsettings.dncenginternal-int.json
@@ -20,8 +20,6 @@
 
     "BuildPool.Windows.10.Amd64.VS2019.Xaml",
     "BuildPool.Server.Amd64.VS2017.Arcade",
-
-    "pr-buildpool.server.amd64.vs2017.arcade-riarenas-test-azure-mo",
   ],
   "HelixCreator": "helixpoolprovider-dncenginternal-int",
   "TimeoutInMinutes": 600,


### PR DESCRIPTION
…er (#529)"

This reverts commit d782eee835f64c6848f666e234edc78e56353c61.

Reverting, this ended up not being used, and no longer needed. 