### PR TITLE
Revert "Migrate to 3.1 (#543)"

### DIFF
--- a/src/Controllers/PoolProviderController.cs
+++ b/src/Controllers/PoolProviderController.cs
@@ -26,9 +26,9 @@ namespace Microsoft.DotNet.HelixPoolProvider.Controllers
         private ILogger _logger;
         private ILoggerFactory _loggerFactory;
         private Config _configuration;
-        private IWebHostEnvironment _hostingEnvironment;
+        private IHostingEnvironment _hostingEnvironment;
 
-        public PoolProviderController(ILoggerFactory loggerFactory, IConfiguration config, IWebHostEnvironment hostingEnvironment)
+        public PoolProviderController(ILoggerFactory loggerFactory, IConfiguration config, IHostingEnvironment hostingEnvironment)
         {
             _logger = loggerFactory.CreateLogger<PoolProviderController>();
             _loggerFactory = loggerFactory;

--- a/src/HelixJobCreator.cs
+++ b/src/HelixJobCreator.cs
@@ -27,12 +27,12 @@ namespace Microsoft.DotNet.HelixPoolProvider
         protected IHelixApi _api;
         protected ILogger _logger;
         protected Config _configuration;
-        protected IWebHostEnvironment _hostingEnvironment;
+        protected IHostingEnvironment _hostingEnvironment;
         protected string _orchestrationId;
         protected string _jobName;
 
         protected HelixJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
-            ILoggerFactory loggerFactory, IWebHostEnvironment hostingEnvironment,
+            ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
             Config configuration, string orchestrationId, string jobName)
         {
             _agentRequestItem = agentRequestItem;

--- a/src/HelixLinuxOSJobCreator.cs
+++ b/src/HelixLinuxOSJobCreator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
     public class HelixLinuxOSJobCreator : HelixJobCreator
     {
         public HelixLinuxOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
-            ILoggerFactory loggerFactory, IWebHostEnvironment hostingEnvironment,
+            ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
             Config configuration, string orchestrationId, string jobName)
             : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 

--- a/src/HelixMacOSJobCreator.cs
+++ b/src/HelixMacOSJobCreator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
     public class HelixMacOSJobCreator : HelixJobCreator
     {
         public HelixMacOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
-            ILoggerFactory loggerFactory, IWebHostEnvironment hostingEnvironment,
+            ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
             Config configuration, string orchestrationId, string jobName)
             : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 

--- a/src/HelixWindowsOSJobCreator.cs
+++ b/src/HelixWindowsOSJobCreator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
     public class HelixWindowsOSJobCreator : HelixJobCreator
     {
         public HelixWindowsOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
-            ILoggerFactory loggerFactory, IWebHostEnvironment hostingEnvironment,
+            ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
             Config configuration, string orchestrationId, string jobName)
             : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 

--- a/src/Microsoft.DotNet.HelixPoolProvider.csproj
+++ b/src/Microsoft.DotNet.HelixPoolProvider.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(MicrosoftApplicationInsightsAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.DotNet.Helix.JobSender" Version="$(MicrosoftDotNetHelixJobSenderVersion)" />

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.HelixPoolProvider
@@ -39,19 +38,14 @@ namespace Microsoft.DotNet.HelixPoolProvider
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseRouting();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapDefaultControllerRoute();
-            });
+            app.UseMvc();
 
             // Add application insights
             loggerFactory.AddApplicationInsights(app.ApplicationServices, LogLevel.Information);


### PR DESCRIPTION
This reverts commit 2185fec16b712917a7ac0b45d8a79656be2c0237.

After merging the following errors started happening:
* System.FormatException at System.Net.Http.Headers.NameValueHeaderValue.CheckValueFormat 
* System.IO.FileNotFoundException at System.Reflection.RuntimeAssembly.nLoad 


I will investigate more and find a way to test it locally but in the meantime I will revert this change as I don't want to block some tests that are running using the int-pool provider
